### PR TITLE
Various doc improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ You may find similarities to this library in the following work:
 
 ## Usage
 
-Clojars coordinates: `[promenade "0.5.1"]`
+[![Clojars Project](https://img.shields.io/clojars/v/promenade.svg)](https://clojars.org/promenade)
 
 See [Documentation](doc/intro.md)
 

--- a/doc/intro.md
+++ b/doc/intro.md
@@ -3,44 +3,150 @@
 Promenade helps to deal with program design oddities. It provides few first-class facilities to express the intent of
 computation at a higher level. You can use Promenade in a new project or refactor an existing one to use it.
 
-
 ## Require namespaces
-
-In Clojure:
 
 ```clojure
 (require '[promenade.core :as prom])
 ```
 
-In ClojureScript:
+### A Simple Example
+
+Say you're trying to write a sequence of instructions where errors can occur:
 
 ```clojure
-(require '[promenade.core :as prom :include-macros true])
-;;
-;; or, its expanded form below
-;;
-(require        '[promenade.core :as prom])
-(require-macros '[promenade.core :as prom])
+(let [v (lookup id)
+      tv (when-not (error? v) (transform v))]
+  (if tv
+    (write-to-db tv)
+    (log-error v)))
 ```
 
-
-## Dealing with success and failure with _Either_
-
-### Expressing success and failure
-
-Failure may be expressed as `(prom/fail failure)`, for example an order item that can not be fulfilled may be
-expressed as follows:
+Such logic is relatively linear, and can often be compressed a bit if you
+want to nil-pun (return `nil` on errors in functions):
 
 ```clojure
-(prom/fail {:part-num  "HP-4196"
-            :order-qty 2
-            :stock-qty 1})
+(some-> id
+  lookup
+  transform
+  write-to-db)
 ```
 
-Any regular value that is not _Failure_ (predicate `prom/failure?`) is considered success.
+but this has a number of weaknesses: you have to use nil, you lose the
+error context (where did things go wrong?), and since the value being
+carried through the sequence becomes `nil`, no possible error recovery
+can be done in the sequence.
 
+Sequences like these can be expressed in this library with more context-aware threading:
 
-### Handling success and failure outcomes
+```clojure
+(either-> id
+  lookup
+  [(attempt-alternate-lookup id)]
+  transform
+  write-to-db
+  [(log-error other-arg)])
+```
+
+In the example above the `id` is left-threaded through a sequence of operations. It works
+*just* like normal threading, except for the presence of the vectors. A vector
+is an `[error-handler optional-success-handler]` entry. It defines what to do
+when there is a problem in the sequence.  Problem values never thread through the normal
+functions, though error handler can recover and continue the sequence.
+
+Thus, in the above example a failure from `lookup` will flow through
+`attempt-alternate-lookup`, and if it fails `log-error`. If there is no
+error or recovery is possible, then `transform` and `write-to-db` will execute.
+
+## Context
+
+This library is primarily concerned with allowing you to cleanly express a sequence of operations
+where the context can indicate that error handling, recovery, or termination
+of the sequence should occur.
+
+The base library defines these contexts:
+
+1. `Failure` - Represents an explicit, code-generated error value.
+2. `Nothing` - Represents an explicit lack of a result.
+3. `Thrown` - Represents a thrown exception.
+
+There are support functions for creating and testing for these:
+
+* `(prom/! form)` - Runs form. If an exception is thrown, returns a `Thrown` context instead. `deref` can be used to access the exception details.
+* `(prom/thrown ex)` - A Thrown with an exception (`deref` can be used to get the exception)
+* `prom/nothing` - The Nothing context
+* `prom/failure` - A generic non-informative Failure
+* `(prom/fail v)` - A Failure with some details (`deref` can be used to get the details)
+* `(prom/failure? c)` - Returns true only if the given context c is a Failure
+* `(prom/nothing? c)` - Returns true only if the given context c is Nothing
+* `(prom/thrown? c)` - Returns true only if the given context c is a Thrown
+* `(prom/context? c)` - Returns true if c is any kind of context (i.e. Nothing, Thrown, Failure). Returns false for all other value types.
+
+These built-in contexts are based on marker protocols, and are therefore extensible.
+
+### Binding Handlers with Context
+
+In general we want to run a regular value through a sequence of functions that
+expect no errors. The happy path. When there is some kind of error we want to be able
+to bind some kind of error/recovery handler and either continue or finish.
+
+This library defines a number of bind functions that encompass one step of this logic. They
+look like this:
+
+```clojure
+(defn bind-CONTEXT-TYPE
+  ([mval success-f] (if (context? mval)  ; Is it some kind of problem?
+                      mval               ; Don't do anything to it...just pass it through
+                      (success-f mval))) ; Do the happy-path operation
+  ([mval failure-f success-f] (cond
+                                (CONTEXT-TEST mval) (failure-f (deref mval)) ; Is it my kind of problem? If so, use the error handler
+                                (context? mval) mval                         ; Is it someone else's problem? If so, pass it on
+                                :otherwise      (success-f mval))))          ; Looks ok. Keep on the happy-path
+```
+
+where `CONTEXT-TYPE` indicates which kind of context you're interested in handling errors for,
+and `CONTEXT-TEST` checks for that kind of context.
+
+Chaining a sequence of these kind of bindings through threading leads to the decision logic
+living in the binds and not your primary logic.
+
+## Handling Explicit Failure
+
+The success and failure results are basically dealt with using the `prom/bind-either` function:
+
+```clojure
+(defn bind-either
+  ([mval success-f] (if (context? mval)
+                      mval
+                      (success-f mval)))
+  ([mval failure-f success-f] (cond
+                                (failure? mval) (failure-f (deref mval))
+                                (context? mval) mval
+                                :otherwise      (success-f mval))))
+```
+
+So, you could write a sequence of possibly failing calls with:
+
+```
+(-> order-id
+  (prom/bind-either (fn [v] (fetch-order-details v)))
+  (prom/bind-either (fn [v] (cancel-order v order-id)) (fn [v] (process-order v)))
+  ...)
+```
+
+where the success functions are only called if the threaded value remains a value (and not any kind of error context).
+
+NOTE: `bind-either` will only *handle* values or `Failure` error contexts. Any other context types simply pass through.
+
+You never write these this way, though. It is much more natural to use the
+built-in threading macros. You may chain together several bind-either operations using the macros
+`either->`, `either->>` and `either-as->`.
+
+### `either` Threading
+
+The `either->` family of threading macros work very much like Clojure's
+standard threading macros. The exception is that error handlers are placed
+within vectors. The threading *does* apply to the first item in the vector,
+but the second item is a function, and is passed the threaded value as the only argument.
 
 Consider an E-Commerce order placement scenario, where we go from a placed order through its fulfilment.
 
@@ -65,34 +171,47 @@ returns a failure. Once the `(cancel-order order-id failure)` step returns failu
 called with that failure argument to take corrective action and return a failure again. If `check-inventory`
 was successful then `process-order` is called, followed by `fulfil-order` on success.
 
-A failure-handler may or may not recover from a _failure_, hence they may return either _failure_ or _success_.
+A failure-handler may or may not recover from a _failure_, hence they may return either _failure_ (via `prom/failure`) or _success_
+(any value that is not an error context).
 However, a failure-handler is only invoked if the prior result is a _failure_. Specifically, in the above example,
-`cancel-order` would deliberately keep the status as _failure_ so that the control can flow to the next step
+`cancel-order` would deliberately return a _failure_ so that the control can flow to the next step
 `stock-replenish-init`.
-
-#### The either-bind variants
-
-The success and failure results are basically dealt with using the `prom/bind-either` function:
-
-```clojure
-(defn bind-either
-  [success-or-failure success-handler]
-  [success-or-failure failure-handler success-handler])
-```
-
-You may chain together several either-bind operations using macros `either->`, `either->>` and `either-as->`.
-
 
 ## Dealing with presence or absence of a value with _Maybe_
 
 ### Expressing a value or its absence thereof
 
-Some times you may want to represent the absence of a value, expressed as `prom/nothing`. This is a special
+Some times you may want to represent the absence of a value, expressed as `prom/nothing` (a Nothing context). This is a special
 value that may participate in other bind chains in Promenade. Any regular value that is not _Nothing_
 (predicate `prom/nothing?`) is considered presence of a value.
 
+#### The bind-maybe variants
 
-### Handling presence or absence of a value
+The value or absence are basically dealt with using the `prom/bind-maybe` function, which follows our
+already established pattern:
+
+```clojure
+(defn bind-maybe
+  ([mval just-f] (if (context? mval)
+                   mval
+                   (just-f mval)))
+  ([mval nothing-f just-f] (cond
+                             (nothing? mval) (nothing-f)
+                             (context? mval) mval
+                             :otherwise      (just-f mval))))
+```
+
+It has an "error-handling" 3-arity version that can call a no-arg nothing handler. If the value
+is a normal value then it passes it through the `just-f` function.
+
+Just like `bind-either`, this function ignores other kinds of incoming contexts (i.e. that are not `Nothing`).
+
+You may chain together several maybe-bind operations using macros `maybe->`, `maybe->>` and `maybe-as->`.
+
+### `maybe` Threading
+
+`bind-maybe` is rarely used directly, just like `bind-either`. There are threading
+macros that make it look just like the success/error handling case.
 
 Let us take the contrived use case of fetching some data from a database that is fronted by a cache.
 
@@ -109,63 +228,56 @@ The `data-id` we begin with is a value that becomes the first argument in the `(
 expression, whose result value is fed into `decompress`. If `fetch-from-cache` returns `prom/nothing` then it
 attempts to fetch the data from database, which may return the value or `prom/nothing`.
 
-#### The maybe-bind variants
+## Exceptions and `bind-trial`
 
-The value or absence are basically dealt with using the `prom/bind-maybe` function:
+The variant for exceptions is `bind-trial`. It is identical to the other two except that it
+uses `thrown?` to detect the cases that should be error-handled.
 
-```clojure
-(defn bind-maybe
-  [value-or-nothing value-handler]
-  [value-or-nothing nothing-handler value-handler])
-```
+The one major difference is that since exceptions normally unroll the stack we'll need
+a way for functions to turn the thrown exception into a context value.
+We can capture exceptions and return as _Thrown_ using the `prom/!` macro, e.g. `(prom/! (third-party-code))`, or construct one using
+`(prom/thrown ex)` function.
 
-You may chain together several maybe-bind operations using macros `maybe->`, `maybe->>` and `maybe-as->`.
-
-
-## Dealing with value or thrown exception with _Trial_
-
-### Expressing a value or thrown exception
-
-We regularly deal with pre-written and third-party code that may throw exceptions. We can capture exceptions
-and return as _Thrown_ using the `prom/!` macro, e.g. `(prom/! (third-party-code))`, or construct one using
-`prom/thrown` function. Any other regular value is considered not a _Thrown_ (predicate `prom/thrown?`).
-
-
-### Handling value or thrown exception
-
-Usually the handling or value vs thrown is similar to handling success vs failure (see above). The only change
-is to capture exceptions and return a thrown result instead of returning a failure.
-
-#### The trial-bind variants
-
-The value or thrown are basically dealt with using the `prom/bind-trial` function:
+For example:
 
 ```clojure
-(defn bind-trial
-  [value-or-thrown value-handler]
-  [value-or-thrown thrown-handler value-handler])
+(defn get-from-db [id]
+  (prom/!
+    (let [v (jdbc/query ...)]
+      v)))
 ```
 
-You may chain together several thrown-bind operations using macros `trial->`, `trial->>` and `trial-as->`.
+will ensure that any thrown exceptions will be converted to a `Thrown` context
+value and returned instead.
 
+You may chain together several bind-trial operations using macros `trial->`, `trial->>` and `trial-as->`.
 
-## Working with various result types
+## Composition
+
+Remember that each bind variant will pass an "unknown" context on to the next bind without acting on it. This
+means you can freely compose the binds (and threading macros) to express complex chains of processing
+that base their operation on the context.
 
 The various result types and bind variants we discussed above may be used together to perform composite operations.
+
 For example, the code snippet below enhances upon the use-case we saw in success/failure handling.
 
 ```clojure
 (-> order-id
   fetch-order-details-from-cache
-  (prom/maybe->   [(fetch-order-details-from-db)])
+  (prom/maybe->   [(fetch-order-details-from-db)]) ; only error-handles Nothing. E.g. a cache miss
   (prom/either->  check-inventory)
-  (prom/either->> [(cancel-order order-id) process-order])
-  (prom/either->  [stock-replenish-init])
-  (prom/either->  fulfil-order)
-  (prom/maybe->   [not-found-error])
-  (prom/trial->   [generate-error]))
+  (prom/either->> [(cancel-order order-id) process-order]) ; Either cancel the order due to Failure, or process valid values
+  (prom/either->  [stock-replenish-init]) ; Only if the prior step result was a Failure
+  (prom/either->  fulfil-order)           ; Only if we still have a valid value
+  (prom/maybe->   [not-found-error])      ; Handle the possiblity that Nothing flowed through from the fetch
+  (prom/trial->   [generate-error]))      ; Handle any exceptions. Any of the above steps could have returned a Thrown
 ```
 
+Remember that all of the behind-the-scene bind functions will flow "unknown" context through to the next. Thus it is perfectly
+fine for *any* of the steps above to return whatever kind of context they want. Suppose you're written every one of the
+functions above by wrapping the body with a `(prom/! ...)`. This means that any unexpected exception would naturally flow down
+to the final `trial->` error handler.
 
 ## Low level control during sequence operations
 

--- a/src/promenade/core.cljc
+++ b/src/promenade/core.cljc
@@ -11,6 +11,7 @@
   "Success/Failure (known as Either) are the dual of each other with respect to an operation result. Similarly, other
   duals include Just/Nothing (known as Maybe) and Result/Exception (known as Trial) on related perspectives. This
   namespace provides unified, standalone and composable mechanism to represent and process such operation outcomes."
+  #?(:cljs (:require-macros promenade.core))
   (:require
     [promenade.internal :as i]
     [promenade.type     :as t]))
@@ -143,7 +144,7 @@
     either->>
     either-as->
     bind-maybe
-    bind-thrown"
+    bind-trial"
   ([mval success-f] (if (context? mval)
                       mval
                       (success-f mval)))
@@ -160,7 +161,7 @@
     maybe->>
     maybe-as->
     bind-either
-    bind-thrown"
+    bind-trial"
   ([mval just-f] (if (context? mval)
                    mval
                    (just-f mval)))
@@ -210,7 +211,7 @@
 
 
 (defmacro either->>
-  "Thread-last expansion using bind. A vector form of one element [x] is applied only to 'failure' leaving
+  "Thread-last expansion using bind-either. A vector form of one element [x] is applied only to 'failure' leaving
   'success' intact.
   Example usage                           Expanded as
   -------------                         | -----------
@@ -230,7 +231,7 @@
 
 
 (defmacro either-as->
-  "Thread-anywhere expansion using bind. A vector form of one element [x] is applied only to 'failure' leaving
+  "Thread-anywhere expansion using bind-either. A vector form of one element [x] is applied only to 'failure' leaving
   'success' intact.
   Example usage                             Expanded as
   -------------                           | -----------
@@ -270,7 +271,7 @@
 
 
 (defmacro maybe->>
-  "Thread-last expansion using bind. A vector form of one element [x] is applied only to 'nothing' leaving
+  "Thread-last expansion using bind-maybe. A vector form of one element [x] is applied only to 'nothing' leaving
   'just' intact.
   Example usage                           Expanded as
   -------------                         | -----------
@@ -290,7 +291,7 @@
 
 
 (defmacro maybe-as->
-  "Thread-anywhere expansion using bind. A vector form of one element [x] is applied only to 'nothing' leaving
+  "Thread-anywhere expansion using bind-maybe. A vector form of one element [x] is applied only to 'nothing' leaving
   'just' intact.
   Example usage                             Expanded as
   -------------                         | -----------
@@ -310,7 +311,7 @@
 
 
 (defmacro trial->
-  "Thread-first expansion using bind-either. A vector form of one element [x] is applied only to 'thrown' leaving
+  "Thread-first expansion using bind-trial. A vector form of one element [x] is applied only to 'thrown' leaving
   'result' intact.
   Example usage                           Expanded as
   -------------                         | -----------


### PR DESCRIPTION
One code change: I added the require-macros to core so that users don't need to do require-macros at their usage sites.

The rest are fixes to a few typos I spotted, and  some additional content to the intro.md that you will hopefully find acceptable. I had a hard time following the documentation as it was, and ended up having to read the source code...but I like the library enough that I figured I could maybe help remedy that situation for future users.

Cheers!